### PR TITLE
Fixed the issue where the input field in the chat box wouldn't reset.

### DIFF
--- a/client/src/components/ChatBox/index.jsx
+++ b/client/src/components/ChatBox/index.jsx
@@ -28,6 +28,9 @@ export const ChatBox = (prop) => {
     if (input.trim() !== "") {
       socket.emit("message", { message: input, roomId });
       setMessages((prevMsg) => [...prevMsg, { message: input, name: "You" }]);
+
+      // Reset input
+      setInput("");
     }
   };
 


### PR DESCRIPTION
After sending a message in the chat room, the message gets delivered, but the input field doesn't clear. The same message remains in the input box.